### PR TITLE
Let the user install packages however they want

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contributers:
 
 ### Dependencies
 
-This pipeline depends on R version >=  and the following R packages:
+This pipeline depends on [R version >=3.5.3](https://www.r-project.org/) and the following R packages:
 
 - docopt
 - dplyr

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ Contributers:
 
 ## Usage
 
+### Dependencies
+
+This pipeline depends on R version >=  and the following R packages:
+
+- docopt
+- dplyr
+- tictoc
+- caret
+- rpart
+- xgboost
+- randomForest
+- kernlab
+- LiblineaR
+- pROC
+- tidyverse
+- yaml
+
+You can install them with [`install.packages`](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Installing-packages) or your preferred manager.
+
+If you'd like to use [conda](https://conda.io/projects/conda/en/latest/), you can use the provided environment file:
+```
+conda env create -f config/environment.yml
+```
+
 ### Command Line Interface
 
 ```
@@ -23,7 +47,7 @@ Usage:
   main.R --seed=<num> --model=<name> --metadata=<csv> --hyperparams=<csv> --outcome=<colname> [--permutation]
   main.R --help
 
-Options
+- Options
   -h --help                  Display this help message.
   --seed=<num>               Random seed.
   --model=<name>             Model name. options:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Contributers:
 This pipeline depends on [R version >=3.5.3](https://www.r-project.org/) and the following R packages:
 
 - docopt
-- dplyr
 - tictoc
 - caret
 - rpart

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ This pipeline depends on R version >=  and the following R packages:
 - tidyverse
 - yaml
 
-You can install them with [`install.packages`](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Installing-packages) or your preferred manager.
+You can install them with [`install.packages`](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#Installing-packages) or your preferred package manager.
 
 If you'd like to use [conda](https://conda.io/projects/conda/en/latest/), you can use the provided environment file:
 ```
 conda env create -f config/environment.yml
 ```
+
+See the [conda documentation](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-environments) for more on managing & using conda environments.
 
 ### Command Line Interface
 

--- a/code/R/main.R
+++ b/code/R/main.R
@@ -39,16 +39,7 @@ deps = c(
 )
 
 for (dep in deps) {
-  if (!(dep %in% installed.packages())) {
-    install.packages(
-      dep,
-      quiet = TRUE,
-      repos = "http://cran.us.r-project.org",
-      dependencies = TRUE
-    )
-
-  }
-  library(dep, verbose = FALSE, character.only = TRUE)
+  library(dep, character.only = TRUE)
 }
 
 args <- docopt(doc)

--- a/code/R/main.R
+++ b/code/R/main.R
@@ -25,7 +25,6 @@ Options
 
 deps = c(
   "docopt",
-  "dplyr",
   "tictoc",
   "caret" ,
   "rpart",

--- a/config/environment.yml
+++ b/config/environment.yml
@@ -1,0 +1,16 @@
+name: ml
+channels:
+  - r
+dependencies:
+  - r-base=3.6.1
+  - r-caret=6.0
+  - r-docopt=0.6.1
+  - r-kernlab=0.9
+  - r-LiblineaR=2.10
+  - r-pROC=1.14.0
+  - r-randomForest=4.6
+  - r-rpart=4.1
+  - r-tictoc=1.0
+  - r-tidyverse=1.2.1
+  - r-xgboost=0.90
+  - r-yaml=2.2.0


### PR DESCRIPTION
Now `main.R` will load the libraries but won't try to install them. If a user doesn't have a required dependency, execution halts with the message:
```R
Error in library(dep, character.only = TRUE) : 
  there is no package called ‘packagename’
Execution halted
```
I think this is good; it fails fast and the default error message seems descriptive enough to hint that the user needs to install the package.

I updated the README with a list of the dependencies & provided a conda environment file for those who would like to use it.