### PR TITLE
Permutation importance

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To test the pipeline with a pre-prepared test dataset, go to `test/README.md`
       
       - Remaining columns should be the features, one feature per column.
 
-Then you need to preproces your own input data with `code/R/setup_model_data.R` to setup your data.
+Then you need to preprocesyour own input data with `code/R/setup_model_data.R` to setup your data.
 
 An example:
 

--- a/code/R/model_pipeline.R
+++ b/code/R/model_pipeline.R
@@ -193,24 +193,24 @@ model_pipeline <- function(data, model, split_number, outcome=NA, hyperparameter
     #     3. Get the feature importances for correlated and uncorrelated feautures
     roc_results <- permutation_importance(trained_model, test_data, first_outcome, second_outcome, outcome, fewer_samples, level)
     if(model=="L1_Linear_SVM" || model=="L2_Linear_SVM" || model=="L2_Logistic_Regression"){
-      feature_importance_non_cor <- trained_model$finalModel$W # Get feature weights 
-      feature_importance_cor <- roc_results # save permutation results
+      feature_importance_weights <- trained_model$finalModel$W # Get feature weights 
+      feature_importance_perm <- roc_results # save permutation results
     }else{
-      feature_importance_non_cor <- NULL
-      feature_importance_cor <- roc_results # save permutation results of cor
+      feature_importance_weights <- NULL
+      feature_importance_perm <- roc_results # save permutation results of cor
     }
   }else{
     print("No permutation test being performed.")
     if(model=="L1_Linear_SVM" || model=="L2_Linear_SVM" || model=="L2_Logistic_Regression"){
       # Get feature weights
-      feature_importance_non_cor <- trained_model$finalModel$W
+      feature_importance_weights <- trained_model$finalModel$W
       # Get feature weights
-      feature_importance_cor <- NULL
+      feature_importance_perm <- NULL
     }else{
       # Get feature weights
-      feature_importance_non_cor <- NULL
+      feature_importance_weights <- NULL
       # Get feature weights
-      feature_importance_cor <- NULL
+      feature_importance_perm <- NULL
     }
   }
 
@@ -218,6 +218,6 @@ model_pipeline <- function(data, model, split_number, outcome=NA, hyperparameter
 
   # ----------------------------Save metrics as vector ------------------------------->
   # Return all the metrics
-  results <- list(cv_auc, test_auc, results_individual, feature_importance_non_cor, feature_importance_cor, trained_model, auprc)
+  results <- list(cv_auc, test_auc, results_individual, feature_importance_weights, feature_importance_perm, trained_model, auprc)
   return(results)
 }

--- a/code/R/model_pipeline.R
+++ b/code/R/model_pipeline.R
@@ -191,14 +191,13 @@ model_pipeline <- function(data, model, split_number, outcome=NA, hyperparameter
     #     1. Predict held-out test-data
     #     2. Calculate ROC and AUROC values on this prediction
     #     3. Get the feature importances for correlated and uncorrelated feautures
-    roc_results <- permutation_importance(trained_model, test_data, first_outcome, second_outcome, outcome, level, fewer_samples)
+    roc_results <- permutation_importance(trained_model, test_data, first_outcome, second_outcome, outcome, fewer_samples, level)
     if(model=="L1_Linear_SVM" || model=="L2_Linear_SVM" || model=="L2_Logistic_Regression"){
-      feature_importance_non_cor <- roc_results[2] # save permutation results
-      feature_importance_cor <- trained_model$finalModel$W # Get feature weights
-    }
-    else{
-      feature_importance_non_cor <- roc_results[2] # save permutation results of non-cor
-      feature_importance_cor <- roc_results[3] # save permutation results of cor
+      feature_importance_non_cor <- trained_model$finalModel$W # Get feature weights 
+      feature_importance_cor <- roc_results # save permutation results
+    }else{
+      feature_importance_non_cor <- NULL
+      feature_importance_cor <- roc_results # save permutation results of cor
     }
   }else{
     print("No permutation test being performed.")
@@ -206,7 +205,7 @@ model_pipeline <- function(data, model, split_number, outcome=NA, hyperparameter
       # Get feature weights
       feature_importance_non_cor <- trained_model$finalModel$W
       # Get feature weights
-      feature_importance_cor <- trained_model$finalModel$W
+      feature_importance_cor <- NULL
     }else{
       # Get feature weights
       feature_importance_non_cor <- NULL

--- a/code/R/run_model.R
+++ b/code/R/run_model.R
@@ -105,7 +105,7 @@ run_model <-
         # Convert to dataframe and add a column noting the model name
        dataframe <- data.frame(imp_features) %>%
            mutate(model=model) %>%
-           write_csv(path=paste0("data/temp/", level,"/all_imp_features_non_cor_results_", model,"_", seed, ".csv"))
+           write_csv(path=paste0("data/temp/", level,"/all_imp_features_weights_results_", model,"_", seed, ".csv"))
         # ------------------------------------------------------------------
 
         # Save all correlated feature importance of the model for 1 datasplit
@@ -113,7 +113,7 @@ run_model <-
         # Convert to dataframe and add a column noting the model name
        dataframe <- data.frame(corr_imp_features) %>%
            mutate(model=model) %>%
-           write_csv(path=paste0("data/temp/", level,"/all_imp_features_cor_results_", model,"_", seed, ".csv"), col_names = TRUE)
+           write_csv(path=paste0("data/temp/", level,"/all_imp_features_perm_results_", model,"_", seed, ".csv"), col_names = TRUE)
 
         # Stop walltime for running model
        secs <- toc()

--- a/code/bash/cat_csv_files.sh
+++ b/code/bash/cat_csv_files.sh
@@ -22,14 +22,14 @@ for model in "L1_Linear_SVM" "L2_Logistic_Regression" "L2_Linear_SVM" "RBF_SVM" 
 do
   	head -1 $SEARCH_DIR/all_hp_results_"$model"_1.csv  > $SEARCH_DIR/combined_all_hp_results_"$model".csv; tail -n +2 -q $SEARCH_DIR/all_hp_results_"$model"_*.csv >> $SEARCH_DIR/combined_all_hp_results_"$model".csv
         head -1 $SEARCH_DIR/best_hp_results_"$model"_1.csv  > $SEARCH_DIR/combined_best_hp_results_"$model".csv; tail -n +2 -q $SEARCH_DIR/best_hp_results_"$model"_*.csv >> $SEARCH_DIR/combined_best_hp_results_"$model".csv
-        head -1 $SEARCH_DIR/all_imp_features_non_cor_results_"$model"_1.csv > $SEARCH_DIR/combined_all_imp_features_non_cor_results_"$model".csv; tail -n +2 -q $SEARCH_DIR/all_imp_features_non_cor_results_"$model"_*.csv >> $SEARCH_DIR/combined_all_imp_features_non_cor_results_"$model".csv
-	head -1 $SEARCH_DIR/all_imp_features_cor_results_"$model"_1.csv > $SEARCH_DIR/combined_all_imp_features_cor_results_"$model".csv; tail -n +2 -q $SEARCH_DIR/all_imp_features_cor_results_"$model"_*.csv >> $SEARCH_DIR/combined_all_imp_features_cor_results_"$model".csv
+        head -1 $SEARCH_DIR/all_imp_features_weights_results_"$model"_1.csv > $SEARCH_DIR/combined_all_imp_features_weights_results_"$model".csv; tail -n +2 -q $SEARCH_DIR/all_imp_features_weights_results_"$model"_*.csv >> $SEARCH_DIR/combined_all_imp_features_weights_results_"$model".csv
+	head -1 $SEARCH_DIR/all_imp_features_perm_results_"$model"_1.csv > $SEARCH_DIR/combined_all_imp_features_perm_results_"$model".csv; tail -n +2 -q $SEARCH_DIR/all_imp_features_perm_"$model"_*.csv >> $SEARCH_DIR/combined_all_imp_features_perm_results_"$model".csv
         head -1 $SEARCH_DIR/walltime_"$model"_1.csv  > $SEARCH_DIR/walltime_"$model".csv; tail -n +2 -q $SEARCH_DIR/walltime_"$model"_*.csv >> $SEARCH_DIR/walltime_"$model".csv
         head -1 $SEARCH_DIR/traintime_"$model"_1.csv  > $SEARCH_DIR/traintime_"$model".csv; tail -n +2 -q $SEARCH_DIR/traintime_"$model"_*.csv >> $SEARCH_DIR/traintime_"$model".csv
 
         mv $SEARCH_DIR/traintime_"$model".csv $FINAL_DIR/traintime_"$model".csv
         mv $SEARCH_DIR/combined_all_hp_results_"$model".csv $FINAL_DIR/combined_all_hp_results_"$model".csv
         mv $SEARCH_DIR/combined_best_hp_results_"$model".csv $FINAL_DIR/combined_best_hp_results_"$model".csv
-	mv $SEARCH_DIR/combined_all_imp_features_non_cor_results_"$model".csv $FINAL_DIR/combined_all_imp_features_non_cor_results_"$model".csv
-        mv $SEARCH_DIR/combined_all_imp_features_cor_results_"$model".csv $FINAL_DIR/combined_all_imp_features_cor_results_"$model".csv
+	mv $SEARCH_DIR/combined_all_imp_features_weights_results_"$model".csv $FINAL_DIR/combined_all_imp_features_weights_results_"$model".csv
+        mv $SEARCH_DIR/combined_all_imp_features_perm_results_"$model".csv $FINAL_DIR/combined_all_imp_features_perm_results_"$model".csv
 done


### PR DESCRIPTION
In this branch I:
- Created a function to group correlated features (fixing a bug in the process).
- Added code to perform each permutation test 100x per feature (or group of correlated features).
- Added code to return both the permuted test AUC as well as the difference between the true test AUC and the permuted test AUC.  

The pipeline now returns the non-correlated feature importance (i.e. feature weights) for logistic regression and SVM regardless of whether a permutation test is performed, and correlated feature importance (difference in true test vs. permuted test AUROC) for all models if a permutation test is performed.

Currently the correlated feature document is parsed for each data split. It might be good to optimize the code so that it only has to be parsed once, as the parsing could take a while depending on the number of correlated features. (Or optimize the code to make the parsing faster.)